### PR TITLE
Only search in running dockers

### DIFF
--- a/kolab/getshell.sh
+++ b/kolab/getshell.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 source ./config.sh
 #assumes the container is running
-CONTAINER=$(docker ps -a | grep $REPONAME:latest | head -n 1 | awk '{ print $1 }')
+CONTAINER=$(docker ps | grep $REPONAME:$TAG | head -n 1 | awk '{ print $1 }')
 docker exec -i -t $CONTAINER bash


### PR DESCRIPTION
-a shows also stops dockers, and if not the first is running, this fails.
